### PR TITLE
Update: Maestro tests

### DIFF
--- a/.github/workflows/gen-android-apk.yml
+++ b/.github/workflows/gen-android-apk.yml
@@ -7,7 +7,11 @@ on:
   # Allows to run this workflow automatically when a tag is pushed
   push:
     tags:
-      - 'v*'
+      - "v*"
+concurrency:
+  # Limit concurrency to 1 for PRs. 'main' concurrency isn't limited.
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -20,8 +24,8 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      
-      - name: Setup and validate gradle wrapper 
+
+      - name: Setup and validate gradle wrapper
         # Will automatically perform wrapper validation on each execution.
         uses: gradle/actions/setup-gradle@v4
 

--- a/.github/workflows/maestro-tests.yml
+++ b/.github/workflows/maestro-tests.yml
@@ -1,16 +1,15 @@
 name: Maestro Android Tests
 
 on:
-  workflow_dispatch:
-    inputs:
-      APP_ID:
-        description: "Application ID to test"
-        required: false
-        default: "com.nisrulz.example.spacexapi"
   push:
     branches: [main]
   pull_request:
     branches: [main]
+
+concurrency:
+  # Limit concurrency to 1 for PRs. 'main' concurrency isn't limited.
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -26,6 +25,8 @@ jobs:
       - name: Setup and validate gradle wrapper
         # Will automatically perform wrapper validation on each execution.
         uses: gradle/actions/setup-gradle@v4
+        continue-on-error: true
+        timeout-minutes: 5
 
       - name: Set Up JDK
         uses: actions/setup-java@v4
@@ -53,25 +54,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2
 
-      - name: Build debug APK
-        run: ./gradlew assembleDebug
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
-      - name: Start Android Emulator
+      - name: Start Android Emulator and Run Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 33
+          api-level: 30
           arch: x86_64
           profile: pixel_6_pro
-          script: echo "Emulator started"
-
-      - name: Install Maestro CLI
-        run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
-          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
-
-      - name: Install APK
-        run: adb install app/build/outputs/apk/debug/app-debug.apk
-
-      - name: Run Maestro Tests
-        run: |
-          maestro test -e APP_ID="${{ github.event.inputs.APP_ID }}" .maestro/
+          emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -no-metrics
+          emulator-boot-timeout: 600
+          disable-animations: true
+          script: ./scripts/run_maestro.sh
+        env:
+          APP_ID: ${{ github.event.inputs.APP_ID }}

--- a/.github/workflows/maestro-tests.yml
+++ b/.github/workflows/maestro-tests.yml
@@ -1,0 +1,77 @@
+name: Maestro Android Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      APP_ID:
+        description: "Application ID to test"
+        required: false
+        default: "com.nisrulz.example.spacexapi"
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code at the latest commit in branch
+        id: checkout-code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Setup and validate gradle wrapper
+        # Will automatically perform wrapper validation on each execution.
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set Up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          cache: "gradle"
+
+      - name: Cache Gradle and wrapper
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Start Android Emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          arch: x86_64
+          profile: pixel_6_pro
+          script: echo "Emulator started"
+
+      - name: Install Maestro CLI
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      - name: Install APK
+        run: adb install app/build/outputs/apk/debug/app-debug.apk
+
+      - name: Run Maestro Tests
+        run: |
+          maestro test -e APP_ID="${{ github.event.inputs.APP_ID }}" .maestro/

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,11 @@ on:
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  # Limit concurrency to 1 for PRs. 'main' concurrency isn't limited.
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,7 +33,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-      
+
       - name: Setup and validate gradle wrapper
         # Will automatically perform wrapper validation on each execution.
         uses: gradle/actions/setup-gradle@v4

--- a/.maestro/launch-app.yml
+++ b/.maestro/launch-app.yml
@@ -1,0 +1,6 @@
+appId: ${APP_ID}
+---
+- launchApp
+- assertVisible: "SpaceX Launches"
+- assertVisible: "Right Action Button"
+- assertVisible: "Bookmark"

--- a/scripts/run_maestro.sh
+++ b/scripts/run_maestro.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e # Exit immediately if a command exits with a non-zero status.
+
+# Wait for emulator to boot
+adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done; input keyevent 82'
+
+echo "✅ Emulator active now"
+
+# Install APK
+./gradlew assembleDebug
+adb install app/build/outputs/apk/debug/app-debug.apk
+
+# Install Maestro CLI
+curl -Ls "https://get.maestro.mobile.dev" | bash
+export PATH="$HOME/.maestro/bin:$PATH"
+export MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true
+export MAESTRO_CLI_NO_ANALYTICS=1
+
+# Run Maestro Tests
+export APP_ID="com.nisrulz.example.spacexapi"
+maestro test -e APP_ID=$APP_ID .maestro/


### PR DESCRIPTION
This pull request introduces several changes to the GitHub workflows and adds new configuration files and scripts for running tests on an Android application. The most important changes include adding concurrency control to workflows, creating a new workflow for Maestro Android tests, and adding scripts and configuration files for running these tests.

Changes to GitHub workflows:

* [`.github/workflows/gen-android-apk.yml`](diffhunk://#diff-c6c9720d39e484f958215faeb130ed33c6295f3f50fff1b461fee120606e9c5cL10-R14): Added concurrency control to limit the number of concurrent runs to 1 for pull requests.
* [`.github/workflows/maestro-tests.yml`](diffhunk://#diff-4be686acd45dcf545dc8b79e3e5cf0e7ae8e43c86d421702e1442da60ead57d1R1-R74): Created a new workflow for running Maestro Android tests, including steps for setting up the environment, caching dependencies, and running the tests.
* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642R20-R24): Added concurrency control to limit the number of concurrent runs to 1 for pull requests.

New scripts and configuration files:

* [`.maestro/launch-app.yml`](diffhunk://#diff-ce8026645175cb80ae5ca8310c1881e56f43895f0d30dabea2ba713e8725bad5R1-R6): Added a Maestro configuration file for launching the app and verifying UI elements.
* [`scripts/run_maestro.sh`](diffhunk://#diff-2453aee09e05d8fdada3fd2c90195d89227be5511bb6d48fc2cdbca13e5ab5f1R1-R22): Added a script to set up and run Maestro tests, including steps for installing the APK and running the tests.