### PR TITLE
Handle Connectivity Check inside repository

### DIFF
--- a/core/common/src/main/AndroidManifest.xml
+++ b/core/common/src/main/AndroidManifest.xml
@@ -1,2 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+</manifest>

--- a/core/common/src/main/java/com/nisrulz/example/spacexapi/common/contract/utils/NetworkUtils.kt
+++ b/core/common/src/main/java/com/nisrulz/example/spacexapi/common/contract/utils/NetworkUtils.kt
@@ -1,0 +1,26 @@
+package com.nisrulz.example.spacexapi.common.contract.utils
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+
+class NetworkUtils(private val context: Context) {
+    fun isInternetAvailable(): Boolean {
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+                ?: return false
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val network = connectivityManager.activeNetwork ?: return false
+            val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+            return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+                    capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+        } else {
+            @Suppress("DEPRECATION")
+            val networkInfo = connectivityManager.activeNetworkInfo
+            @Suppress("DEPRECATION")
+            return networkInfo != null && networkInfo.isConnected
+        }
+    }
+}

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     api(projects.domain)
     implementation(projects.core.networkRetrofit)
     implementation(projects.core.storageRoomdb)
+    implementation(projects.core.common)
 
     // Lifecycle
     implementation(libs.lifecycle.viewmodel.ktx)

--- a/data/src/main/java/com/nisrulz/example/spacexapi/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/nisrulz/example/spacexapi/data/di/RepositoryModule.kt
@@ -1,5 +1,7 @@
 package com.nisrulz.example.spacexapi.data.di
 
+import android.content.Context
+import com.nisrulz.example.spacexapi.common.contract.utils.NetworkUtils
 import com.nisrulz.example.spacexapi.data.repository.LaunchesRepositoryImpl
 import com.nisrulz.example.spacexapi.domain.repository.LaunchesRepository
 import com.nisrulz.example.spacexapi.network.retrofit.SpaceXLaunchesApi
@@ -8,6 +10,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ViewModelScoped
 
 @Module
@@ -17,8 +20,19 @@ class RepositoryModule {
     @ViewModelScoped
     fun provideRepository(
         database: SpaceXLaunchesDatabase,
-        api: SpaceXLaunchesApi
+        api: SpaceXLaunchesApi,
+        networkUtils: NetworkUtils
     ): LaunchesRepository {
-        return LaunchesRepositoryImpl(localDataSource = database.dao, remoteDataSource = api)
+        return LaunchesRepositoryImpl(
+            localDataSource = database.dao,
+            remoteDataSource = api,
+            networkUtils = networkUtils
+        )
     }
+
+    @Provides
+    @ViewModelScoped
+    fun provideNetworkUtils(
+        @ApplicationContext context: Context
+    ) = NetworkUtils(context.applicationContext)
 }

--- a/data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt
+++ b/data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt
@@ -18,26 +18,21 @@ class LaunchesRepositoryImpl(
     private val networkUtils: NetworkUtils
 ) : LaunchesRepository {
     override suspend fun getListOfLaunches(): Flow<List<LaunchInfo>> {
-        // 1. Get list of all bookmarked launches
-        val localBookmarkedLaunches = getAllBookmarked().first()
-
         if (networkUtils.isInternetAvailable()) {
-            // 2. Fetch list of launches from remote API
+            val localBookmarkedLaunches = getAllBookmarked().first()
+
             val apiResponse = remoteDataSource.getAllLaunches()
 
-            // 3. Update local db with updated remote response
             if (apiResponse.isNotEmpty()) {
                 localDataSource.deleteAll()
                 localDataSource.insertAll(apiResponse.toEntityList())
 
-                // Update bookmarked state
                 localBookmarkedLaunches.forEach { bookmarked ->
                     setBookmark(bookmarked.id, bookmarked.isBookmarked)
                 }
             }
         }
 
-        // 4. Fetch the list of launches from local db
         return localDataSource.getAll().map { it.mapToDomainModelList() }
     }
 

--- a/data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt
+++ b/data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.nisrulz.example.spacexapi.data.repository
 
+import com.nisrulz.example.spacexapi.common.contract.utils.NetworkUtils
 import com.nisrulz.example.spacexapi.data.mapper.mapToDomainModel
 import com.nisrulz.example.spacexapi.data.mapper.mapToDomainModelList
 import com.nisrulz.example.spacexapi.data.mapper.toEntityList
@@ -13,23 +14,26 @@ import kotlinx.coroutines.flow.map
 
 class LaunchesRepositoryImpl(
     private val localDataSource: LocalDataSource,
-    private val remoteDataSource: RemoteDataSource
+    private val remoteDataSource: RemoteDataSource,
+    private val networkUtils: NetworkUtils
 ) : LaunchesRepository {
     override suspend fun getListOfLaunches(): Flow<List<LaunchInfo>> {
         // 1. Get list of all bookmarked launches
         val localBookmarkedLaunches = getAllBookmarked().first()
 
-        // 2. Fetch list of launches from remote API
-        val apiResponse = remoteDataSource.getAllLaunches()
+        if (networkUtils.isInternetAvailable()) {
+            // 2. Fetch list of launches from remote API
+            val apiResponse = remoteDataSource.getAllLaunches()
 
-        // 3. Update local db with updated remote response
-        if (apiResponse.isNotEmpty()) {
-            localDataSource.deleteAll()
-            localDataSource.insertAll(apiResponse.toEntityList())
+            // 3. Update local db with updated remote response
+            if (apiResponse.isNotEmpty()) {
+                localDataSource.deleteAll()
+                localDataSource.insertAll(apiResponse.toEntityList())
 
-            // Update bookmarked state
-            localBookmarkedLaunches.forEach { bookmarked ->
-                setBookmark(bookmarked.id, bookmarked.isBookmarked)
+                // Update bookmarked state
+                localBookmarkedLaunches.forEach { bookmarked ->
+                    setBookmark(bookmarked.id, bookmarked.isBookmarked)
+                }
             }
         }
 

--- a/data/src/test/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImplTest.kt
+++ b/data/src/test/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImplTest.kt
@@ -1,27 +1,35 @@
 package com.nisrulz.example.spacexapi.data.repository
 
 import com.google.common.truth.Truth.assertThat
+import com.nisrulz.example.spacexapi.common.contract.utils.NetworkUtils
 import com.nisrulz.example.spacexapi.data.util.TestFactory
 import com.nisrulz.example.spacexapi.data.util.runUnconfinedTest
 import com.nisrulz.example.spacexapi.domain.repository.LaunchesRepository
 import com.nisrulz.example.spacexapi.network.retrofit.SpaceXLaunchesApi
 import com.nisrulz.example.spacexapi.storage.roomdb.LaunchInfoDao
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Test
 
 class LaunchesRepositoryImplTest {
-    private lateinit var sut: LaunchesRepository
-    private lateinit var api: SpaceXLaunchesApi
-    private lateinit var dao: LaunchInfoDao
+
+    private val dao: LaunchInfoDao = mockk()
+    private val api: SpaceXLaunchesApi = mockk()
+    private val networkUtils: NetworkUtils = mockk()
+
+    private val sut: LaunchesRepository = LaunchesRepositoryImpl(
+        localDataSource = dao,
+        remoteDataSource = api,
+        networkUtils = networkUtils
+    )
 
     @Before
     fun setUp() {
-        api = mockk()
-        dao = mockk()
-        sut = LaunchesRepositoryImpl(localDataSource = dao, remoteDataSource = api)
+        every { networkUtils.isInternetAvailable() } returns true
     }
 
     @Test
@@ -121,4 +129,24 @@ class LaunchesRepositoryImplTest {
         // Then
         assertThat(result).isEqualTo(null)
     }
+
+    @Test
+    fun `getListOfLaunches() returns a list of LaunchInfo from local storage only when there is no internet available`() =
+        runUnconfinedTest {
+            // Given
+            every { networkUtils.isInternetAvailable() } returns false
+            coEvery { dao.getAll() } returns flowOf(TestFactory.buildListOfLaunchInfoEntity())
+            val expected = TestFactory.buildListOfLaunchInfo()
+
+            // When
+            val resultFlow = sut.getListOfLaunches()
+
+            // Then
+            resultFlow.collect {
+                assertThat(it).isEqualTo(expected)
+            }
+
+            coVerify(exactly = 0) { api.getAllLaunches() }
+            coVerify(exactly = 1) { dao.getAll() }
+        }
 }


### PR DESCRIPTION
This pull request introduces network utility enhancements and integrates them into the repository module. The changes ensure the application checks for internet connectivity before making network requests. The most important changes include adding a network utility class, updating the repository to use this utility, and modifying the dependency injection setup.

Network Utility Enhancements:

* [`core/common/src/main/AndroidManifest.xml`](diffhunk://#diff-548cc4eec31349f8b8cd89de439d94b8b96918653c0d20907e46978b6ab4ba9eL2-R5): Added the `ACCESS_NETWORK_STATE` permission to the manifest file.
* [`core/common/src/main/java/com/nisrulz/example/spacexapi/common/contract/utils/NetworkUtils.kt`](diffhunk://#diff-ad4cd405129f5d65af6e874eb7f63b467e981ef6f22f6cff8bd4836d65c3e2e3R1-R26): Introduced the `NetworkUtils` class to check for internet connectivity.

Repository Integration:

* [`data/src/main/java/com/nisrulz/example/spacexapi/data/di/RepositoryModule.kt`](diffhunk://#diff-615acdc40a7eefc0a1b5b4a7c0d0cae9fe642c81b04548192b44e8d9c4843e2cR3-R4): Updated the `RepositoryModule` to provide `NetworkUtils` and injected it into the repository. [[1]](diffhunk://#diff-615acdc40a7eefc0a1b5b4a7c0d0cae9fe642c81b04548192b44e8d9c4843e2cR3-R4) [[2]](diffhunk://#diff-615acdc40a7eefc0a1b5b4a7c0d0cae9fe642c81b04548192b44e8d9c4843e2cR13) [[3]](diffhunk://#diff-615acdc40a7eefc0a1b5b4a7c0d0cae9fe642c81b04548192b44e8d9c4843e2cL20-R37)
* [`data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt`](diffhunk://#diff-ede3b55d863a26c919988f708f0b052cb06d88a57a1c9f60ead0d8e951d107aeR3): Modified the `LaunchesRepositoryImpl` to use `NetworkUtils` for checking internet availability before fetching data from the remote API. [[1]](diffhunk://#diff-ede3b55d863a26c919988f708f0b052cb06d88a57a1c9f60ead0d8e951d107aeR3) [[2]](diffhunk://#diff-ede3b55d863a26c919988f708f0b052cb06d88a57a1c9f60ead0d8e951d107aeL16-L36)

Dependency and Testing Updates:

* [`data/build.gradle.kts`](diffhunk://#diff-d2805d83e69c4c4d37fbacc9f7f2f95fb0e10310cf588d44510c6c6cf40207beR28): Added the `core.common` project as a dependency.
* [`data/src/test/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImplTest.kt`](diffhunk://#diff-72d0f22332e5f6cda831c9517bd23e43ae7d67827a7c6943c666e31867915023R4-R32): Updated tests to mock `NetworkUtils` and added a test case to verify behavior when there is no internet available. [[1]](diffhunk://#diff-72d0f22332e5f6cda831c9517bd23e43ae7d67827a7c6943c666e31867915023R4-R32) [[2]](diffhunk://#diff-72d0f22332e5f6cda831c9517bd23e43ae7d67827a7c6943c666e31867915023R132-R151)