### PR TITLE
Make the maestro tests only run on PR opened by dependabot or triggered manually

### DIFF
--- a/.github/workflows/maestro-tests.yml
+++ b/.github/workflows/maestro-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened]
     branches: [main]
 
 concurrency:
@@ -14,6 +15,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout code at the latest commit in branch
         id: checkout-code


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration in the `.github/workflows/maestro-tests.yml` file. The changes are aimed at refining the conditions under which the tests are triggered and executed.

Changes to workflow trigger and execution conditions:

* [`.github/workflows/maestro-tests.yml`](diffhunk://#diff-4be686acd45dcf545dc8b79e3e5cf0e7ae8e43c86d421702e1442da60ead57d1R7): Added a condition to trigger the workflow only when a pull request is opened.
* [`.github/workflows/maestro-tests.yml`](diffhunk://#diff-4be686acd45dcf545dc8b79e3e5cf0e7ae8e43c86d421702e1442da60ead57d1R18): Added a condition to run the test job only if the actor is 'dependabot[bot]' or if the event name is 'workflow_dispatch'.