### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 An Offline first Android app to consume the SpaceX Backend API [`https://github.com/r-spacex/SpaceX-API`](https://github.com/r-spacex/SpaceX-API).
 
 ---
-[![Unit tests](https://github.com/nisrulz/android-spacex-app/actions/workflows/run-tests.yml/badge.svg)](https://github.com/nisrulz/android-spacex-app/actions/workflows/run-tests.yml) [![Validate Gradle Wrapper](https://github.com/nisrulz/android-spacex-app/actions/workflows/validate-gradlew.yml/badge.svg)](https://github.com/nisrulz/android-spacex-app/actions/workflows/validate-gradlew.yml) [![Generate Android APK](https://github.com/nisrulz/android-spacex-app/actions/workflows/gen-android-apk.yml/badge.svg)](https://github.com/nisrulz/android-spacex-app/actions/workflows/gen-android-apk.yml)
+[![Unit tests](https://github.com/nisrulz/android-spacex-app/actions/workflows/run-tests.yml/badge.svg)](https://github.com/nisrulz/android-spacex-app/actions/workflows/run-tests.yml) [![Generate Android APK](https://github.com/nisrulz/android-spacex-app/actions/workflows/gen-android-apk.yml/badge.svg)](https://github.com/nisrulz/android-spacex-app/actions/workflows/gen-android-apk.yml) [![Maestro Android Tests](https://github.com/nisrulz/android-spacex-app/actions/workflows/maestro-tests.yml/badge.svg)](https://github.com/nisrulz/android-spacex-app/actions/workflows/maestro-tests.yml)
 
 ![Screenshot](./repo_assets/screenshot.png)
 


### PR DESCRIPTION
This pull request includes a small change to the `Readme.md` file. The change involves updating the badges for CI workflows, specifically removing the "Validate Gradle Wrapper" badge and adding a new "Maestro Android Tests" badge.

Changes in CI workflow badges:

* [`Readme.md`](diffhunk://#diff-1550ec65ac92f65817fc28928dfef526912b5f52356ff43651369bae92f56031L6-R6): Removed the "Validate Gradle Wrapper" badge and added the "Maestro Android Tests" badge.