### PR TITLE
Update maestro-tests.yml

### DIFF
--- a/.github/workflows/maestro-tests.yml
+++ b/.github/workflows/maestro-tests.yml
@@ -1,12 +1,6 @@
 name: Maestro Android Tests
 
 on:
-  # Allows to run this workflow when a commit it pushed to the specified branches
-  push:
-    paths-ignore:
-      - "**/*.md"
-    branches:
-      - main
   # Allows to run this workflow when a Pull Request is made with the set target branches
   pull_request:
     #


### PR DESCRIPTION
The most important change is the removal of the configuration that allowed the workflow to run on push events to the `main` branch while ignoring markdown files.

Workflow configuration changes:

* [`.github/workflows/maestro-tests.yml`](diffhunk://#diff-4be686acd45dcf545dc8b79e3e5cf0e7ae8e43c86d421702e1442da60ead57d1L4-L9): Removed the `push` event configuration that allowed the workflow to run on commits pushed to the `main` branch, excluding markdown files.