### PR TITLE
Update deps

### DIFF
--- a/.github/workflows/maestro-tests.yml
+++ b/.github/workflows/maestro-tests.yml
@@ -84,7 +84,7 @@ jobs:
             ./scripts/run_maestro.sh
 
       - name: Create comment with test results
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         if: always()
         with:
           script: |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,18 +2,18 @@
 
 #region ---- Kotlin version dependent
 # https://github.com/JetBrains/kotlin/releases
-kotlin = "2.3.20"
+kotlin = "2.3.21"
 # https://github.com/google/ksp/releases
 ksp = "2.3.6"
 #endregion
 
 #region ---- Android Core
-agp = "9.1.0"
-androidTools = "32.1.0"
+agp = "9.2.1"
+androidTools = "32.2.1"
 core-ktx = "1.18.0"
 lifecycleVer = "2.10.0"
 appcompat = "1.7.1"
-navigation3 = "1.0.1"
+navigation3 = "1.1.1"
 #endregion
 
 # Logs
@@ -24,12 +24,12 @@ material3 = "1.10.0"
 
 #region ---- Kotlin
 kotlinxCoroutines = "1.10.2"
-kotlinxSerializationJson = "1.10.0"
+kotlinxSerializationJson = "1.11.0"
 #endregion
 
 #region ---- Jetpack Compose
 activity-compose = "1.13.0"
-compose-bom = "2026.03.01"
+compose-bom = "2026.05.00"
 #endregion
 
 


### PR DESCRIPTION
This pull request updates several dependencies and tools to their latest versions, focusing on the Kotlin toolchain, Android build tools, and related libraries. These upgrades help ensure compatibility with the latest features and bug fixes.

Dependency and toolchain upgrades:

* Updated Kotlin to version `2.3.21` and KSP to `2.3.6` in `gradle/libs.versions.toml` to use the latest language features and improvements.
* Upgraded Android Gradle Plugin (`agp`) to `9.2.1` and Android Tools to `32.2.1` for improved build performance and compatibility.
* Updated Jetpack Navigation library to `1.1.1` and Compose BOM to `2026.05.00` for access to the latest Compose and navigation features. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL5-R16) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL27-R32)
* Upgraded `kotlinxSerializationJson` to `1.11.0` for serialization improvements and bug fixes.

CI workflow update:

* Updated the `actions/github-script` GitHub Action from version `v8` to `v9` in `.github/workflows/maestro-tests.yml` for improved security and new features.