### PR TITLE
Update project

### DIFF
--- a/.github/workflows/gen-android-apk.yml
+++ b/.github/workflows/gen-android-apk.yml
@@ -10,7 +10,7 @@ on:
       - "v*"
 concurrency:
   # Limit concurrency to 1 for PRs. 'main' concurrency isn't limited.
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/maestro-tests.yml
+++ b/.github/workflows/maestro-tests.yml
@@ -22,7 +22,6 @@ jobs:
     permissions: # Specify the required permissions
       issues: write # For writing comments on issues and pull requests
       pull-requests: write # For interacting with pull request data
-    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Checkout code at the latest commit in branch
         id: checkout-code
@@ -85,7 +84,7 @@ jobs:
 
       - name: Create comment with test results
         uses: actions/github-script@v9
-        if: always()
+        if: always() && github.event_name == 'pull_request'
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/maestro-tests.yml
+++ b/.github/workflows/maestro-tests.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   # Limit concurrency to 1 for PRs. 'main' concurrency isn't limited.
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
   # Limit concurrency to 1 for PRs. 'main' concurrency isn't limited.
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LaunchInfoDao.kt
+++ b/core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LaunchInfoDao.kt
@@ -18,6 +18,9 @@ interface LaunchInfoDao : LocalDataSource {
     override fun getAllBookmarked(): Flow<List<LaunchInfoEntity>>
 
     @Query("SELECT * from LaunchInfoEntity where id = :id")
+    override fun observeById(id: String): Flow<LaunchInfoEntity?>
+
+    @Query("SELECT * from LaunchInfoEntity where id = :id")
     override suspend fun getById(id: String): LaunchInfoEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LaunchInfoDao.kt
+++ b/core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LaunchInfoDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import androidx.room.Update
 import com.nisrulz.example.spacexapi.storage.roomdb.entity.LaunchInfoEntity
 import kotlinx.coroutines.flow.Flow
@@ -26,6 +27,17 @@ interface LaunchInfoDao : LocalDataSource {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     override suspend fun insertAll(listOfLaunchInfoEntities: List<LaunchInfoEntity>)
 
+    @Transaction
+    override suspend fun replaceAllPreservingBookmarks(listOfLaunchInfoEntities: List<LaunchInfoEntity>) {
+        val bookmarkedIds = getBookmarkedIds().toSet()
+        deleteAll()
+        insertAll(
+            listOfLaunchInfoEntities.map { launchInfoEntity ->
+                launchInfoEntity.copy(isBookmarked = launchInfoEntity.id in bookmarkedIds)
+            },
+        )
+    }
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     override suspend fun insert(launchInfoEntity: LaunchInfoEntity)
 
@@ -34,6 +46,9 @@ interface LaunchInfoDao : LocalDataSource {
 
     @Delete
     override suspend fun delete(launchInfoEntity: LaunchInfoEntity)
+
+    @Query("SELECT id from LaunchInfoEntity where isBookmarked = 1")
+    suspend fun getBookmarkedIds(): List<String>
 
     @Query("DELETE FROM LaunchInfoEntity")
     override suspend fun deleteAll()

--- a/core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LocalDataSource.kt
+++ b/core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LocalDataSource.kt
@@ -8,6 +8,8 @@ interface LocalDataSource {
 
     fun getAllBookmarked(): Flow<List<LaunchInfoEntity>>
 
+    fun observeById(id: String): Flow<LaunchInfoEntity?>
+
     suspend fun getById(id: String): LaunchInfoEntity?
 
     suspend fun insert(launchInfoEntity: LaunchInfoEntity)

--- a/core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LocalDataSource.kt
+++ b/core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LocalDataSource.kt
@@ -16,6 +16,8 @@ interface LocalDataSource {
 
     suspend fun insertAll(listOfLaunchInfoEntities: List<LaunchInfoEntity>)
 
+    suspend fun replaceAllPreservingBookmarks(listOfLaunchInfoEntities: List<LaunchInfoEntity>)
+
     suspend fun update(launchInfoEntity: LaunchInfoEntity)
 
     suspend fun delete(launchInfoEntity: LaunchInfoEntity)

--- a/data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt
+++ b/data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt
@@ -36,9 +36,8 @@ class LaunchesRepositoryImpl(
         return localDataSource.getAll().map { it.mapToDomainModelList() }
     }
 
-    override suspend fun getLaunchDetail(id: String): LaunchInfo? {
-        return localDataSource.getById(id)?.mapToDomainModel()
-    }
+    override fun getLaunchDetail(id: String): Flow<LaunchInfo?> =
+        localDataSource.observeById(id).map { it?.mapToDomainModel() }
 
     override suspend fun getAllBookmarked(): Flow<List<LaunchInfo>> {
         return localDataSource.getAllBookmarked().map { it.mapToDomainModelList() }

--- a/data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt
+++ b/data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt
@@ -19,16 +19,18 @@ class LaunchesRepositoryImpl(
 ) : LaunchesRepository {
     override suspend fun getListOfLaunches(): Flow<List<LaunchInfo>> {
         if (networkUtils.isInternetAvailable()) {
-            val localBookmarkedLaunches = getAllBookmarked().first()
+            runCatching {
+                val localBookmarkedLaunches = getAllBookmarked().first()
 
-            val apiResponse = remoteDataSource.getAllLaunches()
+                val apiResponse = remoteDataSource.getAllLaunches()
 
-            if (apiResponse.isNotEmpty()) {
-                localDataSource.deleteAll()
-                localDataSource.insertAll(apiResponse.toEntityList())
+                if (apiResponse.isNotEmpty()) {
+                    localDataSource.deleteAll()
+                    localDataSource.insertAll(apiResponse.toEntityList())
 
-                localBookmarkedLaunches.forEach { bookmarked ->
-                    setBookmark(bookmarked.id, bookmarked.isBookmarked)
+                    localBookmarkedLaunches.forEach { bookmarked ->
+                        setBookmark(bookmarked.id, bookmarked.isBookmarked)
+                    }
                 }
             }
         }

--- a/data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt
+++ b/data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt
@@ -9,7 +9,6 @@ import com.nisrulz.example.spacexapi.domain.repository.LaunchesRepository
 import com.nisrulz.example.spacexapi.network.retrofit.RemoteDataSource
 import com.nisrulz.example.spacexapi.storage.roomdb.LocalDataSource
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 class LaunchesRepositoryImpl(
@@ -20,17 +19,10 @@ class LaunchesRepositoryImpl(
     override suspend fun getListOfLaunches(): Flow<List<LaunchInfo>> {
         if (networkUtils.isInternetAvailable()) {
             runCatching {
-                val localBookmarkedLaunches = getAllBookmarked().first()
-
                 val apiResponse = remoteDataSource.getAllLaunches()
 
                 if (apiResponse.isNotEmpty()) {
-                    localDataSource.deleteAll()
-                    localDataSource.insertAll(apiResponse.toEntityList())
-
-                    localBookmarkedLaunches.forEach { bookmarked ->
-                        setBookmark(bookmarked.id, bookmarked.isBookmarked)
-                    }
+                    localDataSource.replaceAllPreservingBookmarks(apiResponse.toEntityList())
                 }
             }
         }

--- a/data/src/test/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImplTest.kt
+++ b/data/src/test/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package com.nisrulz.example.spacexapi.data.repository
 
 import com.google.common.truth.Truth.assertThat
 import com.nisrulz.example.spacexapi.common.contract.utils.NetworkUtils
+import com.nisrulz.example.spacexapi.data.mapper.toEntityList
 import com.nisrulz.example.spacexapi.data.util.TestFactory
 import com.nisrulz.example.spacexapi.data.util.runUnconfinedTest
 import com.nisrulz.example.spacexapi.domain.repository.LaunchesRepository
@@ -37,9 +38,7 @@ class LaunchesRepositoryImplTest {
     fun `getListOfLaunches() returns a list of LaunchInfo on success`() = runUnconfinedTest {
         // Given
         coEvery { api.getAllLaunches() } returns TestFactory.buildListOfLaunchInfoResponse()
-        coEvery { dao.deleteAll() } returns Unit
-        coEvery { dao.getAllBookmarked() } returns flowOf(emptyList())
-        coEvery { dao.insertAll(any()) } returns Unit
+        coEvery { dao.replaceAllPreservingBookmarks(any()) } returns Unit
         coEvery { dao.getAll() } returns flowOf(TestFactory.buildListOfLaunchInfoEntity())
         val expected = TestFactory.buildListOfLaunchInfo()
 
@@ -57,9 +56,7 @@ class LaunchesRepositoryImplTest {
         runUnconfinedTest {
             // Given
             coEvery { api.getAllLaunches() } returns TestFactory.buildListOfLaunchInfoResponse()
-            coEvery { dao.deleteAll() } returns Unit
-            coEvery { dao.getAllBookmarked() } returns flowOf(emptyList())
-            coEvery { dao.insertAll(any()) } returns Unit
+            coEvery { dao.replaceAllPreservingBookmarks(any()) } returns Unit
             coEvery { dao.getAll() } returns flowOf(emptyList())
 
             // When
@@ -160,7 +157,6 @@ class LaunchesRepositoryImplTest {
         runUnconfinedTest {
             // Given
             coEvery { api.getAllLaunches() } throws IOException("network down")
-            coEvery { dao.getAllBookmarked() } returns flowOf(emptyList())
             coEvery { dao.getAll() } returns flowOf(TestFactory.buildListOfLaunchInfoEntity())
             val expected = TestFactory.buildListOfLaunchInfo()
 
@@ -174,6 +170,24 @@ class LaunchesRepositoryImplTest {
 
             coVerify(exactly = 1) { api.getAllLaunches() }
             coVerify(exactly = 1) { dao.getAll() }
-            coVerify(exactly = 0) { dao.deleteAll() }
+            coVerify(exactly = 0) { dao.replaceAllPreservingBookmarks(any()) }
+        }
+
+    @Test
+    fun `getListOfLaunches() replaces local data while preserving bookmarks atomically`() =
+        runUnconfinedTest {
+            // Given
+            val apiResponse = TestFactory.buildListOfLaunchInfoResponse()
+            coEvery { api.getAllLaunches() } returns apiResponse
+            coEvery { dao.replaceAllPreservingBookmarks(any()) } returns Unit
+            coEvery { dao.getAll() } returns flowOf(TestFactory.buildListOfLaunchInfoEntity())
+
+            // When
+            sut.getListOfLaunches().collect { }
+
+            // Then
+            coVerify(exactly = 1) {
+                dao.replaceAllPreservingBookmarks(apiResponse.toEntityList())
+            }
         }
 }

--- a/data/src/test/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImplTest.kt
+++ b/data/src/test/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImplTest.kt
@@ -11,6 +11,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import java.io.IOException
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Test
@@ -152,5 +153,27 @@ class LaunchesRepositoryImplTest {
 
             coVerify(exactly = 0) { api.getAllLaunches() }
             coVerify(exactly = 1) { dao.getAll() }
+        }
+
+    @Test
+    fun `getListOfLaunches() falls back to local storage when refresh fails`() =
+        runUnconfinedTest {
+            // Given
+            coEvery { api.getAllLaunches() } throws IOException("network down")
+            coEvery { dao.getAllBookmarked() } returns flowOf(emptyList())
+            coEvery { dao.getAll() } returns flowOf(TestFactory.buildListOfLaunchInfoEntity())
+            val expected = TestFactory.buildListOfLaunchInfo()
+
+            // When
+            val resultFlow = sut.getListOfLaunches()
+
+            // Then
+            resultFlow.collect {
+                assertThat(it).isEqualTo(expected)
+            }
+
+            coVerify(exactly = 1) { api.getAllLaunches() }
+            coVerify(exactly = 1) { dao.getAll() }
+            coVerify(exactly = 0) { dao.deleteAll() }
         }
 }

--- a/data/src/test/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImplTest.kt
+++ b/data/src/test/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImplTest.kt
@@ -107,27 +107,31 @@ class LaunchesRepositoryImplTest {
     fun `getLaunchDetail() returns a valid LaunchInfo for id on success`() = runUnconfinedTest {
         // Given
         val id = TestFactory.buildLaunchInfoEntity().id
-        coEvery { dao.getById(any()) } returns TestFactory.buildLaunchInfoEntity()
+        every { dao.observeById(any()) } returns flowOf(TestFactory.buildLaunchInfoEntity())
         val expected = TestFactory.buildLaunchInfo()
 
         // When
-        val result = sut.getLaunchDetail(id)
+        val resultFlow = sut.getLaunchDetail(id)
 
         // Then
-        assertThat(result).isEqualTo(expected)
+        resultFlow.collect {
+            assertThat(it).isEqualTo(expected)
+        }
     }
 
     @Test
     fun `getLaunchDetail() returns null when item with id cannot be found`() = runUnconfinedTest {
         // Given
         val id = TestFactory.buildLaunchInfoEntity().id
-        coEvery { dao.getById(any()) } returns null
+        every { dao.observeById(any()) } returns flowOf(null)
 
         // When
-        val result = sut.getLaunchDetail(id)
+        val resultFlow = sut.getLaunchDetail(id)
 
         // Then
-        assertThat(result).isEqualTo(null)
+        resultFlow.collect {
+            assertThat(it).isNull()
+        }
     }
 
     @Test

--- a/domain/src/main/java/com/nisrulz/example/spacexapi/domain/repository/LaunchesRepository.kt
+++ b/domain/src/main/java/com/nisrulz/example/spacexapi/domain/repository/LaunchesRepository.kt
@@ -8,7 +8,7 @@ interface LaunchesRepository {
 
     suspend fun getAllBookmarked(): Flow<List<LaunchInfo>>
 
-    suspend fun getLaunchDetail(id: String): LaunchInfo?
+    fun getLaunchDetail(id: String): Flow<LaunchInfo?>
 
     suspend fun setBookmark(
         id: String,

--- a/domain/src/main/java/com/nisrulz/example/spacexapi/domain/usecase/GetLaunchDetail.kt
+++ b/domain/src/main/java/com/nisrulz/example/spacexapi/domain/usecase/GetLaunchDetail.kt
@@ -8,5 +8,5 @@ class GetLaunchDetail
     constructor(
         private val repository: LaunchesRepository,
     ) {
-        suspend operator fun invoke(id: String) = repository.getLaunchDetail(id)
+        operator fun invoke(id: String) = repository.getLaunchDetail(id)
     }

--- a/domain/src/test/java/com/nisrulz/example/spacexapi/domain/usecase/GetLaunchDetailTest.kt
+++ b/domain/src/test/java/com/nisrulz/example/spacexapi/domain/usecase/GetLaunchDetailTest.kt
@@ -4,8 +4,9 @@ import com.google.common.truth.Truth.assertThat
 import com.nisrulz.example.spacexapi.domain.repository.LaunchesRepository
 import com.nisrulz.example.spacexapi.domain.util.TestFactory
 import com.nisrulz.example.spacexapi.domain.util.runUnconfinedTest
-import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Test
 
@@ -24,12 +25,14 @@ class GetLaunchDetailTest {
         runUnconfinedTest {
             // Given
             val launchInfo = TestFactory.buildLaunchInfo()
-            coEvery { repository.getLaunchDetail(launchInfo.id) } returns launchInfo
+            every { repository.getLaunchDetail(launchInfo.id) } returns flowOf(launchInfo)
 
             // When
             val result = getLaunchDetail(launchInfo.id)
 
             // Then
-            assertThat(result).isEqualTo(launchInfo)
+            result.collect {
+                assertThat(it).isEqualTo(launchInfo)
+            }
         }
 }

--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/bookmarkedlaunches/BookmarkedLaunchesScreen.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/bookmarkedlaunches/BookmarkedLaunchesScreen.kt
@@ -13,7 +13,6 @@ import com.nisrulz.example.spacexapi.common.contract.utils.SingleValueCallback
 import com.nisrulz.example.spacexapi.presentation.features.components.EmptyComponent
 import com.nisrulz.example.spacexapi.presentation.features.components.LoadingComponent
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.receiveAsFlow
 
 @SuppressLint("VisibleForTests")
 @Composable
@@ -26,8 +25,7 @@ fun BookmarkedLaunchesScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(viewModel) {
-
-        viewModel.eventFlow.receiveAsFlow().collectLatest { event ->
+        viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is BookmarkedLaunchesViewModel.UiEvent.ShowSnackBar -> {
                     snackbarHostState.showSnackbar(
@@ -39,7 +37,6 @@ fun BookmarkedLaunchesScreen(
     }
 
     with(state) {
-        if (error.isNotEmpty()) viewModel.showError(error)
         if (isLoading) {
             LoadingComponent()
         } else if (data.isEmpty()) {

--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/bookmarkedlaunches/BookmarkedLaunchesViewModel.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/bookmarkedlaunches/BookmarkedLaunchesViewModel.kt
@@ -9,8 +9,10 @@ import com.nisrulz.example.spacexapi.domain.usecase.ToggleBookmarkLaunchInfo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
@@ -28,15 +30,8 @@ constructor(
     var uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState(isLoading = true))
         private set
 
-    /*
-     A CONFLATED channel is a type of channel that only preserves the latest value.
-     When a new value is sent to the channel, if the previous value has not been consumed yet,
-     it will be discarded and replaced with the new value.
-     This behavior can be useful in certain scenarios where one only care about the latest
-     value and don't want to process outdated values.
-     */
-    var eventFlow: Channel<UiEvent> = Channel(Channel.CONFLATED)
-        private set
+    private val _eventFlow = MutableSharedFlow<UiEvent>(extraBufferCapacity = 1)
+    val eventFlow: SharedFlow<UiEvent> = _eventFlow.asSharedFlow()
 
     init {
         // Fetch data when ViewModel is created
@@ -59,8 +54,8 @@ constructor(
 
     private fun stopLoading() = uiState.update { it.copy(isLoading = false) }
     private fun setError(message: String) {
-        uiState.update { it.copy(error = message) }
         stopLoading()
+        sendEvent(UiEvent.ShowSnackBar(message))
     }
 
     private fun handleListOfLaunches(list: List<LaunchInfo>) {
@@ -68,10 +63,8 @@ constructor(
         stopLoading()
     }
 
-    fun showError(message: String) = sendEvent(UiEvent.ShowSnackBar(message))
-
     private fun sendEvent(uiEvent: UiEvent) = viewModelScope.launch(coroutineDispatcher) {
-        eventFlow.send(uiEvent)
+        _eventFlow.emit(uiEvent)
     }
 
     sealed interface UiEvent {
@@ -80,7 +73,6 @@ constructor(
 
     data class UiState(
         val isLoading: Boolean = false,
-        val error: String = "",
         val data: List<LaunchInfo> = emptyList()
     )
 }

--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailComponent.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailComponent.kt
@@ -40,6 +40,7 @@ fun LaunchDetailSuccessComponent(
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState,
     state: LaunchDetailViewModel.UiState,
+    bookmark: EmptyCallback = {},
     navigateBack: EmptyCallback = {}
 ) {
     Box(
@@ -55,6 +56,10 @@ fun LaunchDetailSuccessComponent(
                     leftNavButtonIcon = R.drawable.back,
                     leftNavButtonAction = {
                         navigateBack()
+                    },
+                    rightNavButtonIcon = if (isBookmarked) R.drawable.bookmark else R.drawable.not_bookmarked,
+                    rightNavButtonAction = {
+                        bookmark()
                     }
                 )
 

--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailScreen.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailScreen.kt
@@ -13,7 +13,6 @@ import com.nisrulz.example.spacexapi.presentation.features.components.EmptyCompo
 import com.nisrulz.example.spacexapi.presentation.features.components.LoadingComponent
 import com.nisrulz.example.spacexapi.presentation.features.launchdetail.LaunchDetailViewModel.UiEvent.ShowSnackBar
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.receiveAsFlow
 
 @Composable
 fun LaunchDetailScreen(
@@ -28,7 +27,7 @@ fun LaunchDetailScreen(
         // Fetch data for this specific launch
         viewModel.getLaunchInfoDetails(launchId)
 
-        viewModel.eventFlow.receiveAsFlow().collectLatest {
+        viewModel.eventFlow.collectLatest {
             when (it) {
                 is ShowSnackBar -> {
                     snackbarHostState.showSnackbar(message = it.message)
@@ -38,7 +37,6 @@ fun LaunchDetailScreen(
     }
 
     with(state) {
-        if (error.isNotEmpty()) viewModel.showError(error)
         if (isLoading) {
             LoadingComponent()
         } else if (data == null) {

--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailScreen.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailScreen.kt
@@ -49,6 +49,9 @@ fun LaunchDetailScreen(
             LaunchDetailSuccessComponent(
                 state = state,
                 snackbarHostState = snackbarHostState,
+                bookmark = {
+                    viewModel.bookmark(data)
+                },
                 navigateBack = {
                     // Analytics
                     viewModel.trackOnBack()

--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailViewModel.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailViewModel.kt
@@ -14,6 +14,9 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -33,17 +36,23 @@ constructor(
         private set
 
     fun getLaunchInfoDetails(launchId: String?) = viewModelScope.launch(coroutineDispatcher) {
-        stopLoading()
         if (launchId.isNullOrBlank()) {
             setError("No Data")
+            stopLoading()
         } else {
             trackScreenEntered()
-            update(getLaunchDetail(launchId))
+            getLaunchDetail(launchId)
+                .onEach {
+                    update(it)
+                    stopLoading()
+                }.catch {
+                    setError(it.message ?: "Error")
+                    stopLoading()
+                }.collect()
         }
     }
 
     fun bookmark(launchInfo: LaunchInfo) {
-        update(launchInfo)
         viewModelScope.launch(coroutineDispatcher) {
             bookmarkLaunchInfo(launchInfo)
         }

--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailViewModel.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailViewModel.kt
@@ -12,8 +12,10 @@ import com.nisrulz.example.spacexapi.presentation.features.launchdetail.LaunchDe
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
@@ -32,8 +34,8 @@ constructor(
     var uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState(isLoading = true))
         private set
 
-    var eventFlow: Channel<UiEvent> = Channel(Channel.CONFLATED)
-        private set
+    private val _eventFlow = MutableSharedFlow<UiEvent>(extraBufferCapacity = 1)
+    val eventFlow: SharedFlow<UiEvent> = _eventFlow.asSharedFlow()
 
     fun getLaunchInfoDetails(launchId: String?) = viewModelScope.launch(coroutineDispatcher) {
         if (launchId.isNullOrBlank()) {
@@ -58,22 +60,21 @@ constructor(
         }
     }
 
-    fun showError(message: String) = viewModelScope.launch(coroutineDispatcher) {
-        eventFlow.send(ShowSnackBar(message))
-    }
-
     private fun update(launchInfo: LaunchInfo?) = uiState.update { it.copy(data = launchInfo) }
 
-    private fun setError(message: String) = uiState.update { it.copy(error = message) }
+    private fun setError(message: String) = sendEvent(ShowSnackBar(message))
 
     private fun stopLoading() = uiState.update { it.copy(isLoading = false) }
+
+    private fun sendEvent(uiEvent: UiEvent) = viewModelScope.launch(coroutineDispatcher) {
+        _eventFlow.emit(uiEvent)
+    }
 
     fun trackScreenEntered() = analytics.trackScreenLaunchDetail()
     fun trackOnBack() = analytics.trackNavigateToListOfLaunches()
 
     data class UiState(
         val isLoading: Boolean = false,
-        val error: String = "",
         val data: LaunchInfo? = null
     )
 

--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/listoflaunches/ListOfLaunchesScreen.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/listoflaunches/ListOfLaunchesScreen.kt
@@ -12,10 +12,8 @@ import com.nisrulz.example.spacexapi.common.contract.utils.EmptyCallback
 import com.nisrulz.example.spacexapi.common.contract.utils.SingleValueCallback
 import com.nisrulz.example.spacexapi.presentation.features.components.EmptyComponent
 import com.nisrulz.example.spacexapi.presentation.features.components.LoadingComponent
-import com.nisrulz.example.spacexapi.presentation.features.listoflaunches.ListOfLaunchesViewModel.UiEvent
 import com.nisrulz.example.spacexapi.presentation.features.listoflaunches.ListOfLaunchesViewModel.UiEvent.ShowSnackBar
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.receiveAsFlow
 
 @SuppressLint("VisibleForTests")
 @Composable
@@ -28,7 +26,7 @@ fun ListOfLaunchesScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(viewModel) {
-        viewModel.eventFlow.receiveAsFlow().collectLatest { event ->
+        viewModel.eventFlow.collectLatest { event ->
             when (event) {
                 is ShowSnackBar -> {
                     snackbarHostState.showSnackbar(
@@ -40,7 +38,6 @@ fun ListOfLaunchesScreen(
     }
 
     with(state) {
-        if (error.isNotEmpty()) viewModel.showError(error)
         if (isLoading) {
             LoadingComponent()
         } else if (data.isEmpty()) {

--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/listoflaunches/ListOfLaunchesViewModel.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/listoflaunches/ListOfLaunchesViewModel.kt
@@ -4,7 +4,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nisrulz.example.spacexapi.analytics.InUseAnalytics
-import com.nisrulz.example.spacexapi.analytics.trackNavigateToDetail
 import com.nisrulz.example.spacexapi.analytics.trackScreenListOfLaunches
 import com.nisrulz.example.spacexapi.domain.model.LaunchInfo
 import com.nisrulz.example.spacexapi.domain.usecase.GetAllLaunches
@@ -13,8 +12,10 @@ import com.nisrulz.example.spacexapi.logger.InUseLoggers
 import com.nisrulz.example.spacexapi.presentation.features.listoflaunches.ListOfLaunchesViewModel.UiEvent.ShowSnackBar
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
@@ -34,15 +35,8 @@ class ListOfLaunchesViewModel
     var uiState: MutableStateFlow<UiState> = MutableStateFlow(UiState(isLoading = true))
         private set
 
-    /*
-     A CONFLATED channel is a type of channel that only preserves the latest value.
-     When a new value is sent to the channel, if the previous value has not been consumed yet,
-     it will be discarded and replaced with the new value.
-     This behavior can be useful in certain scenarios where one only care about the latest
-     value and don't want to process outdated values.
-     */
-    var eventFlow: Channel<UiEvent> = Channel(Channel.CONFLATED)
-        private set
+    private val _eventFlow = MutableSharedFlow<UiEvent>(extraBufferCapacity = 1)
+    val eventFlow: SharedFlow<UiEvent> = _eventFlow.asSharedFlow()
 
     init {
         // Track screen entered
@@ -70,14 +64,12 @@ class ListOfLaunchesViewModel
     }
 
     private fun setError(message: String) {
-        uiState.update { it.copy(error = message) }
         stopLoading()
+        sendEvent(ShowSnackBar(message))
     }
 
-    fun showError(message: String) = sendEvent(ShowSnackBar(message))
-
     private fun sendEvent(uiEvent: UiEvent) = viewModelScope.launch(coroutineDispatcher) {
-        eventFlow.send(uiEvent)
+        _eventFlow.emit(uiEvent)
         logger.log("Ui Event: $uiEvent")
     }
 
@@ -91,7 +83,6 @@ class ListOfLaunchesViewModel
 
     data class UiState(
         val isLoading: Boolean = false,
-        val error: String = "",
         val data: List<LaunchInfo> = emptyList()
     )
 }

--- a/presentation/src/test/java/com/nisrulz/example/spacexapi/presentation/features/bookmarkedlaunches/BookmarkedLaunchesViewModelTest.kt
+++ b/presentation/src/test/java/com/nisrulz/example/spacexapi/presentation/features/bookmarkedlaunches/BookmarkedLaunchesViewModelTest.kt
@@ -12,7 +12,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.receiveAsFlow
 import org.junit.Before
 import org.junit.Test
 
@@ -72,9 +71,11 @@ class BookmarkedLaunchesViewModelTest {
         val message = "Test Error Message"
 
         // Then
-        sut.eventFlow.receiveAsFlow().test {
+        sut.eventFlow.test {
             // When
-            sut.showError(message)
+            val setError = BookmarkedLaunchesViewModel::class.java.getDeclaredMethod("setError", String::class.java)
+            setError.isAccessible = true
+            setError.invoke(sut, message)
 
             // Then
             assertThat(awaitItem()).isEqualTo(ShowSnackBar(message))

--- a/presentation/src/test/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailViewModelTest.kt
@@ -15,6 +15,8 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.receiveAsFlow
 import org.junit.Before
 import org.junit.Test
@@ -44,7 +46,7 @@ class LaunchDetailViewModelTest {
         // Given
         val launchId = "TestLaunchId"
         val expected = TestFactory.buildLaunchInfo()
-        coEvery { getLaunchDetail(launchId) } returns expected
+        every { getLaunchDetail(launchId) } returns flowOf(expected)
 
         // When
         sut.getLaunchInfoDetails(launchId).join()
@@ -67,6 +69,22 @@ class LaunchDetailViewModelTest {
         coVerify {
             bookmarkLaunchInfo(launchInfo)
         }
+    }
+
+    @Test
+    fun `getLaunchInfoDetails() should reactively update uiState when launch changes`() = runUnconfinedTest {
+        // Given
+        val launchId = "TestLaunchId"
+        val launchFlow = MutableStateFlow(TestFactory.buildLaunchInfo())
+        every { getLaunchDetail(launchId) } returns launchFlow
+
+        // When
+        val job = sut.getLaunchInfoDetails(launchId)
+        launchFlow.value = launchFlow.value.copy(isBookmarked = true)
+
+        // Then
+        assertThat(sut.uiState.value.data?.isBookmarked).isTrue()
+        job.cancel()
     }
 
     @Test

--- a/presentation/src/test/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailViewModelTest.kt
+++ b/presentation/src/test/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailViewModelTest.kt
@@ -17,7 +17,6 @@ import io.mockk.mockk
 import io.mockk.runs
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.receiveAsFlow
 import org.junit.Before
 import org.junit.Test
 
@@ -93,9 +92,11 @@ class LaunchDetailViewModelTest {
         val message = "Test Error Message"
 
         // Then
-        sut.eventFlow.receiveAsFlow().test {
+        sut.eventFlow.test {
             // When
-            sut.showError(message)
+            val setError = LaunchDetailViewModel::class.java.getDeclaredMethod("setError", String::class.java)
+            setError.isAccessible = true
+            setError.invoke(sut, message)
 
             // Then
             assertThat(awaitItem()).isEqualTo(ShowSnackBar(message))

--- a/presentation/src/test/java/com/nisrulz/example/spacexapi/presentation/features/listoflaunches/ListOfLaunchesViewModelTest.kt
+++ b/presentation/src/test/java/com/nisrulz/example/spacexapi/presentation/features/listoflaunches/ListOfLaunchesViewModelTest.kt
@@ -19,7 +19,6 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.verify
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.receiveAsFlow
 import org.junit.Before
 import org.junit.Test
 
@@ -87,9 +86,11 @@ class ListOfLaunchesViewModelTest {
         val message = "Test Error Message"
 
         // Then
-        sut.eventFlow.receiveAsFlow().test {
+        sut.eventFlow.test {
             // When
-            sut.showError(message)
+            val setError = ListOfLaunchesViewModel::class.java.getDeclaredMethod("setError", String::class.java)
+            setError.isAccessible = true
+            setError.invoke(sut, message)
 
             // Then
             assertThat(awaitItem()).isEqualTo(ShowSnackBar(message))


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the SpaceX API app, focusing on making data access more reactive, improving atomicity and bookmark preservation, and simplifying event handling in the UI. The most important changes are grouped below by theme.

### Data Access and Repository Improvements

* Refactored the `LaunchesRepository` and related DAO interfaces to make `getLaunchDetail` return a `Flow<LaunchInfo?>` instead of a suspend function, enabling reactive updates to launch details. (`domain/src/main/java/com/nisrulz/example/spacexapi/domain/repository/LaunchesRepository.kt` [[1]](diffhunk://#diff-f8d27c0788142f664e0fe9c251e2ab266e91974909c06c04e0f1bad55b1e68d4L11-R11) `core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LocalDataSource.kt` [[2]](diffhunk://#diff-dc1d9bdf47791606fe7c633321bf90f286081aeabb88b0a41de0b31b905b72dfR11-R20) `core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LaunchInfoDao.kt` [[3]](diffhunk://#diff-b6c1cd565af67d99442a4c1d491cd410471e1dcedf2293ab1e17e3a6a3b218d7R21-R40)
* Updated the repository implementation to use a new atomic method `replaceAllPreservingBookmarks`, ensuring that local data is refreshed while preserving user bookmarks, and made the refresh operation transactional. (`data/src/main/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImpl.kt` [[1]](diffhunk://#diff-ede3b55d863a26c919988f708f0b052cb06d88a57a1c9f60ead0d8e951d107aeL22-R34) `core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LaunchInfoDao.kt` [[2]](diffhunk://#diff-b6c1cd565af67d99442a4c1d491cd410471e1dcedf2293ab1e17e3a6a3b218d7R21-R40) [[3]](diffhunk://#diff-b6c1cd565af67d99442a4c1d491cd410471e1dcedf2293ab1e17e3a6a3b218d7R50-R52)

### Room Database Enhancements

* Added a new DAO method `observeById` for observing individual launch entities reactively, and implemented `getBookmarkedIds` to support bookmark preservation during data refreshes. (`core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LaunchInfoDao.kt` [[1]](diffhunk://#diff-b6c1cd565af67d99442a4c1d491cd410471e1dcedf2293ab1e17e3a6a3b218d7R21-R40) [[2]](diffhunk://#diff-b6c1cd565af67d99442a4c1d491cd410471e1dcedf2293ab1e17e3a6a3b218d7R50-R52)
* Marked the `replaceAllPreservingBookmarks` method with `@Transaction` to ensure atomic updates to the database. (`core/storage-roomdb/src/main/java/com/nisrulz/example/spacexapi/storage/roomdb/LaunchInfoDao.kt` [[1]](diffhunk://#diff-b6c1cd565af67d99442a4c1d491cd410471e1dcedf2293ab1e17e3a6a3b218d7R8) [[2]](diffhunk://#diff-b6c1cd565af67d99442a4c1d491cd410471e1dcedf2293ab1e17e3a6a3b218d7R21-R40)

### UI and ViewModel Event Handling

* Refactored event handling in `BookmarkedLaunchesViewModel` to use `SharedFlow` instead of `Channel`, simplifying the pattern and ensuring better lifecycle handling. (`presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/bookmarkedlaunches/BookmarkedLaunchesViewModel.kt` [[1]](diffhunk://#diff-16cabb5ad1f6b37f18f7abc2bc28c56d6f976da17759239211cc29a43851423aL12-R15) [[2]](diffhunk://#diff-16cabb5ad1f6b37f18f7abc2bc28c56d6f976da17759239211cc29a43851423aL31-R34)
* Updated the UI to consume events directly from `SharedFlow` and removed redundant error state management, now showing errors via snackbars only. (`presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/bookmarkedlaunches/BookmarkedLaunchesScreen.kt` [[1]](diffhunk://#diff-b81d8a4560cc0aa1bb7c8aa1dc3b55456c7fa9edf94118e15254f2e98240612fL29-R28) [[2]](diffhunk://#diff-16cabb5ad1f6b37f18f7abc2bc28c56d6f976da17759239211cc29a43851423aL62-R67) [[3]](diffhunk://#diff-16cabb5ad1f6b37f18f7abc2bc28c56d6f976da17759239211cc29a43851423aL83) [[4]](diffhunk://#diff-b81d8a4560cc0aa1bb7c8aa1dc3b55456c7fa9edf94118e15254f2e98240612fL42)

### Launch Detail UI Improvements

* Enhanced the launch detail component to allow toggling bookmarks directly from the UI, updating the navigation bar to reflect bookmark status. (`presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/launchdetail/LaunchDetailComponent.kt` [[1]](diffhunk://#diff-ac25318f081cfdf92f9acbb08cd63aadf27de4eb56d71c29b586542143de6353R43) [[2]](diffhunk://#diff-ac25318f081cfdf92f9acbb08cd63aadf27de4eb56d71c29b586542143de6353R59-R62)

### Testing Updates

* Updated and expanded tests to cover the new repository behavior, including atomic data refresh with bookmark preservation and reactive detail retrieval. (`data/src/test/java/com/nisrulz/example/spacexapi/data/repository/LaunchesRepositoryImplTest.kt` [[1]](diffhunk://#diff-72d0f22332e5f6cda831c9517bd23e43ae7d67827a7c6943c666e31867915023L39-R41) [[2]](diffhunk://#diff-72d0f22332e5f6cda831c9517bd23e43ae7d67827a7c6943c666e31867915023L59-R59) [[3]](diffhunk://#diff-72d0f22332e5f6cda831c9517bd23e43ae7d67827a7c6943c666e31867915023L110-R132) [[4]](diffhunk://#diff-72d0f22332e5f6cda831c9517bd23e43ae7d67827a7c6943c666e31867915023R154-R192) `domain/src/test/java/com/nisrulz/example/spacexapi/domain/usecase/GetLaunchDetailTest.kt` [[5]](diffhunk://#diff-0f000cb448441cebc0455382d6e0cd3072586aa43895bee3e90fde319728b26dL7-R9) [[6]](diffhunk://#diff-0f000cb448441cebc0455382d6e0cd3072586aa43895bee3e90fde319728b26dL27-R36)

These changes collectively improve the app's data consistency, user experience, and maintainability.