### PR TITLE
Replace depreacted statusBarColor with new api

### DIFF
--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/MainActivity.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/features/MainActivity.kt
@@ -2,6 +2,7 @@ package com.nisrulz.example.spacexapi.presentation.features
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import com.nisrulz.example.spacexapi.presentation.navigation.AppNavigation
 import com.nisrulz.example.spacexapi.presentation.theme.SpacexAPITheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -20,7 +22,9 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(Color.Black.toArgb())
+        )
         setContent {
             AppEntryPoint()
         }

--- a/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/theme/Theme.kt
+++ b/presentation/src/main/java/com/nisrulz/example/spacexapi/presentation/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.nisrulz.example.spacexapi.presentation.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -10,25 +9,20 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
 private val DarkColorScheme =
     darkColorScheme(
         primary = Purple80,
         secondary = PurpleGrey80,
-        tertiary = Pink80,
+        tertiary = Pink80
     )
 
 private val LightColorScheme =
     lightColorScheme(
         primary = Purple40,
         secondary = PurpleGrey40,
-        tertiary = Pink40,
+        tertiary = Pink40
         /* Other default colors to override
         background = Color(0xFFFFFBFE),
         surface = Color(0xFFFFFBFE),
@@ -45,7 +39,7 @@ fun SpacexAPITheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
-    content: @Composable () -> Unit,
+    content: @Composable () -> Unit
 ) {
     val colorScheme =
         when {
@@ -55,24 +49,17 @@ fun SpacexAPITheme(
             }
 
             darkTheme -> DarkColorScheme
+
             else -> LightColorScheme
         }
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = Color.Black.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
-        }
-    }
 
     CompositionLocalProvider(
-        LocalDimens provides Dimens(),
+        LocalDimens provides Dimens()
     ) {
         MaterialTheme(
             colorScheme = colorScheme,
             typography = Typography,
-            content = content,
+            content = content
         )
     }
 }


### PR DESCRIPTION
This pull request updates how the app handles the status bar color and appearance. The logic for setting the status bar to black and controlling its icon color has been moved from the custom theme code to the `MainActivity`, using the `enableEdgeToEdge` API for a more modern and streamlined approach. Unused imports and redundant code have also been removed from the theme file.

**System bar and theme improvements:**

* The status bar color and icon appearance are now set in `MainActivity` using `enableEdgeToEdge` with `SystemBarStyle.dark(Color.Black.toArgb())`, instead of being managed in the `SpacexAPITheme` composable. This centralizes system bar configuration and uses the recommended API. [[1]](diffhunk://#diff-1d0957d1509055f27eb4c60ad0563bb5632ce9998f4d83a8a848e0c8bb4e1a39R5) [[2]](diffhunk://#diff-1d0957d1509055f27eb4c60ad0563bb5632ce9998f4d83a8a848e0c8bb4e1a39R15) [[3]](diffhunk://#diff-1d0957d1509055f27eb4c60ad0563bb5632ce9998f4d83a8a848e0c8bb4e1a39L23-R27)
* Removed all status bar-related logic and associated imports from `Theme.kt`, simplifying the theme code and preventing duplication of system bar handling. [[1]](diffhunk://#diff-207d72c5918d0a7afc3a9e8751b9f834f29b5f3fef7d3d473e1e3d6e5e5f9baeL3) [[2]](diffhunk://#diff-207d72c5918d0a7afc3a9e8751b9f834f29b5f3fef7d3d473e1e3d6e5e5f9baeL13-R25) [[3]](diffhunk://#diff-207d72c5918d0a7afc3a9e8751b9f834f29b5f3fef7d3d473e1e3d6e5e5f9baeR52-R62)

**Code cleanup:**

* Cleaned up formatting and removed unnecessary trailing commas in color scheme definitions and function parameters in `Theme.kt`, improving code readability. [[1]](diffhunk://#diff-207d72c5918d0a7afc3a9e8751b9f834f29b5f3fef7d3d473e1e3d6e5e5f9baeL13-R25) [[2]](diffhunk://#diff-207d72c5918d0a7afc3a9e8751b9f834f29b5f3fef7d3d473e1e3d6e5e5f9baeL48-R42)